### PR TITLE
rav1e 0.6.0 git 2022-10-18

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-    rav1e-0.5.1.tar.gz: 8cb54b8e918b394e32d2faa433e3554bd32e2377
+    rav1e-p20221018.tar.gz: d7fe516484c3ea8215d9c1ddd288862abec97a12f30c83566a6326dab5960f73

--- a/rav1e.spec
+++ b/rav1e.spec
@@ -6,13 +6,13 @@
 %global optflags %{optflags} -O3
 
 Name:		rav1e
-Version:	0.5.1
+Version:	0.6.0
 Release:	1
 Summary:	The fastest and safest AV1 encoder
 License:	BSD
 Group:		System/Libraries
 URL:		https://github.com/xiph/rav1e
-Source0:	https://github.com/xiph/rav1e/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:	https://github.com/xiph/rav1e/archive/refs/tags/p20221018.tar.gz
 BuildRequires:	rust
 BuildRequires:	rust-src
 BuildRequires:	cargo


### PR DESCRIPTION
Ever since rav1e's 0.5.1 release, there have been large quality and speedups, and since 0.6.0 won't be released for a while yet, I think updating it to this week's release is good.